### PR TITLE
Coroutines Homework

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,4 +41,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.11.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.squareup.picasso:picasso:2.71828'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.3"
+    implementation "androidx.activity:activity-ktx:1.9.0"
 }

--- a/app/src/main/java/otus/homework/coroutines/CatData.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatData.kt
@@ -1,0 +1,6 @@
+package otus.homework.coroutines
+
+data class CatData(
+    val fact: String,
+    val pictureUrl: String
+)

--- a/app/src/main/java/otus/homework/coroutines/CatFactViewModel.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatFactViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import java.net.SocketTimeoutException
 
 class CatFactViewModel(
     private val catsFactService: CatsService,
@@ -19,7 +20,10 @@ class CatFactViewModel(
     private var fetchJob: Job? = null
 
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        _catsLiveData.value = Result.Error(throwable)
+        when (throwable) {
+            is SocketTimeoutException -> _catsLiveData.value = Result.Error.ServerError(throwable)
+            else -> _catsLiveData.value = Result.Error.GeneralError(throwable)
+        }
     }
 
     fun fetchCatData() {

--- a/app/src/main/java/otus/homework/coroutines/CatFactViewModel.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatFactViewModel.kt
@@ -1,0 +1,49 @@
+package otus.homework.coroutines
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+
+class CatFactViewModel(
+    private val catsFactService: CatsService,
+    private val catsPicturesService: CatsPicturesService
+) : ViewModel() {
+
+    private val _catsLiveData = MutableLiveData<Result<CatData>>()
+    val catsLiveData: LiveData<Result<CatData>> get() = _catsLiveData
+    private var fetchJob: Job? = null
+
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        _catsLiveData.value = Result.Error(throwable)
+    }
+
+    fun fetchCatData() {
+        cancelFetch()
+
+        fetchJob = viewModelScope.launch(exceptionHandler) {
+            val factRequest = async { catsFactService.getCatFact() }
+            val imageRequest = async { catsPicturesService.getCatPicture() }
+
+            val fact = factRequest.await()
+            val picture = imageRequest.await()
+
+            _catsLiveData.value =
+                Result.Success(CatData(fact.fact, picture.first().url))
+        }
+    }
+
+    fun cancelFetch() {
+        fetchJob?.cancel()
+        fetchJob = null
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        cancelFetch()
+    }
+}

--- a/app/src/main/java/otus/homework/coroutines/CatFactViewModel.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatFactViewModel.kt
@@ -42,8 +42,4 @@ class CatFactViewModel(
         fetchJob = null
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        cancelFetch()
-    }
 }

--- a/app/src/main/java/otus/homework/coroutines/CatsPicturesService.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatsPicturesService.kt
@@ -1,0 +1,10 @@
+package otus.homework.coroutines
+
+import retrofit2.http.GET
+
+interface CatsPicturesService {
+
+    @GET("v1/images/search")
+    suspend fun getCatPicture(): List<Picture>
+
+}

--- a/app/src/main/java/otus/homework/coroutines/CatsPresenter.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatsPresenter.kt
@@ -1,6 +1,7 @@
 package otus.homework.coroutines
 
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.net.SocketTimeoutException
 

--- a/app/src/main/java/otus/homework/coroutines/CatsPresenter.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatsPresenter.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.net.SocketTimeoutException
+import kotlin.coroutines.cancellation.CancellationException
 
 class CatsPresenter(
     private val catsFactService: CatsService,
@@ -20,6 +21,8 @@ class CatsPresenter(
                 fetchAndUpdateCatInfo()
             } catch (e: SocketTimeoutException) {
                 connectionErrorHandler.onError()
+            } catch (e: CancellationException) {
+                throw e
             } catch(e: Exception) {
                 CrashMonitor.trackWarning(e.message)
             }

--- a/app/src/main/java/otus/homework/coroutines/CatsPresenter.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatsPresenter.kt
@@ -20,7 +20,7 @@ class CatsPresenter(
             } catch (e: SocketTimeoutException) {
                 connectionErrorHandler.onError()
             } catch(e: Exception) {
-                CrashMonitor.trackWarning(e.message ?: UNKNOWN_ERROR)
+                CrashMonitor.trackWarning(e.message)
             }
         }
     }
@@ -52,9 +52,5 @@ class CatsPresenter(
 
     fun detachView() {
         _catsView = null
-    }
-
-    companion object {
-        private const val UNKNOWN_ERROR = "Unknown error"
     }
 }

--- a/app/src/main/java/otus/homework/coroutines/CatsService.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatsService.kt
@@ -1,10 +1,9 @@
 package otus.homework.coroutines
 
-import retrofit2.Call
 import retrofit2.http.GET
 
 interface CatsService {
 
     @GET("fact")
-    fun getCatFact() : Call<Fact>
+    suspend fun getCatFact(): Fact
 }

--- a/app/src/main/java/otus/homework/coroutines/CatsView.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatsView.kt
@@ -14,11 +14,22 @@ class CatsView @JvmOverloads constructor(
 ) : ConstraintLayout(context, attrs, defStyleAttr), ICatsView {
 
     var presenter: CatsPresenter? = null
+    var viewModel: CatFactViewModel? = null
 
     override fun onFinishInflate() {
         super.onFinishInflate()
+
         findViewById<Button>(R.id.button).setOnClickListener {
-            presenter?.onInitComplete()
+
+            when (hwTaskFeature) {
+                FeatureFlag.HW_TASK_1_CAT_PRESENTER -> {
+                    presenter?.onInitComplete()
+                }
+
+                FeatureFlag.HW_TASK_3_CAT_VIEW_MODEL -> {
+                    viewModel?.fetchCatData()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/otus/homework/coroutines/CatsView.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatsView.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.widget.Button
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
+import com.squareup.picasso.Picasso
 
 class CatsView @JvmOverloads constructor(
     context: Context,
@@ -12,7 +13,7 @@ class CatsView @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : ConstraintLayout(context, attrs, defStyleAttr), ICatsView {
 
-    var presenter :CatsPresenter? = null
+    var presenter: CatsPresenter? = null
 
     override fun onFinishInflate() {
         super.onFinishInflate()
@@ -21,12 +22,14 @@ class CatsView @JvmOverloads constructor(
         }
     }
 
-    override fun populate(fact: Fact) {
-        findViewById<TextView>(R.id.fact_textView).text = fact.fact
+    override fun populate(catData: CatData) {
+        findViewById<TextView>(R.id.fact_textView).text = catData.fact
+        val imageView = findViewById<android.widget.ImageView>(R.id.cat_image)
+        Picasso.get().load(catData.pictureUrl).into(imageView)
     }
 }
 
 interface ICatsView {
 
-    fun populate(fact: Fact)
+    fun populate(catData: CatData)
 }

--- a/app/src/main/java/otus/homework/coroutines/CatsViewModelFactory.kt
+++ b/app/src/main/java/otus/homework/coroutines/CatsViewModelFactory.kt
@@ -1,0 +1,19 @@
+package otus.homework.coroutines
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+
+class CatsViewModelFactory(
+    private val catsFactService: CatsService,
+    private val catsPicturesService: CatsPicturesService
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(CatFactViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return CatFactViewModel(catsFactService, catsPicturesService) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/otus/homework/coroutines/ConnectionErrorHandler.kt
+++ b/app/src/main/java/otus/homework/coroutines/ConnectionErrorHandler.kt
@@ -1,0 +1,5 @@
+package otus.homework.coroutines
+
+interface ConnectionErrorHandler {
+    fun onError()
+}

--- a/app/src/main/java/otus/homework/coroutines/CrashMonitor.kt
+++ b/app/src/main/java/otus/homework/coroutines/CrashMonitor.kt
@@ -9,7 +9,7 @@ object CrashMonitor {
     /**
      * Pretend this is Crashlytics/AppCenter
      */
-    fun trackWarning(message: String) {
+    fun trackWarning(message: String?) {
         Log.w(tag, "A crash has been detected: $message")
     }
 }

--- a/app/src/main/java/otus/homework/coroutines/CrashMonitor.kt
+++ b/app/src/main/java/otus/homework/coroutines/CrashMonitor.kt
@@ -1,10 +1,15 @@
 package otus.homework.coroutines
 
+import android.util.Log
+
 object CrashMonitor {
+
+    private val tag = javaClass.simpleName
 
     /**
      * Pretend this is Crashlytics/AppCenter
      */
-    fun trackWarning() {
+    fun trackWarning(message: String) {
+        Log.w(tag, "A crash has been detected: $message")
     }
 }

--- a/app/src/main/java/otus/homework/coroutines/DiContainer.kt
+++ b/app/src/main/java/otus/homework/coroutines/DiContainer.kt
@@ -5,12 +5,26 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 class DiContainer {
 
-    private val retrofit by lazy {
+    private val catFactsRetrofit by lazy {
         Retrofit.Builder()
-            .baseUrl("https://catfact.ninja/")
+            .baseUrl(CAT_FACTS_BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }
 
-    val service by lazy { retrofit.create(CatsService::class.java) }
+    val catFactsService by lazy { catFactsRetrofit.create(CatsService::class.java) }
+
+    private val catPicturesRetrofit by lazy {
+        Retrofit.Builder()
+            .baseUrl(CAT_PICTURES_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    val catPicturesService by lazy { catPicturesRetrofit.create(CatsPicturesService::class.java) }
+
+    companion object {
+        private const val CAT_FACTS_BASE_URL = "https://catfact.ninja/"
+        private const val CAT_PICTURES_BASE_URL = "https://api.thecatapi.com/"
+    }
 }

--- a/app/src/main/java/otus/homework/coroutines/FeatureFlag.kt
+++ b/app/src/main/java/otus/homework/coroutines/FeatureFlag.kt
@@ -1,0 +1,8 @@
+package otus.homework.coroutines
+
+enum class FeatureFlag {
+    HW_TASK_1_CAT_PRESENTER,
+    HW_TASK_3_CAT_VIEW_MODEL,
+}
+
+val hwTaskFeature = FeatureFlag.HW_TASK_3_CAT_VIEW_MODEL

--- a/app/src/main/java/otus/homework/coroutines/MainActivity.kt
+++ b/app/src/main/java/otus/homework/coroutines/MainActivity.kt
@@ -16,7 +16,9 @@ class MainActivity : AppCompatActivity(), ConnectionErrorHandler {
         val view = layoutInflater.inflate(R.layout.activity_main, null) as CatsView
         setContentView(view)
 
-        catsPresenter = CatsPresenter(diContainer.service, this)
+        catsPresenter = CatsPresenter(
+            diContainer.catFactsService, diContainer.catPicturesService, this
+        )
         view.presenter = catsPresenter
         catsPresenter.attachView(view)
         catsPresenter.onInitComplete()

--- a/app/src/main/java/otus/homework/coroutines/MainActivity.kt
+++ b/app/src/main/java/otus/homework/coroutines/MainActivity.kt
@@ -2,8 +2,9 @@ package otus.homework.coroutines
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.widget.Toast
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), ConnectionErrorHandler {
 
     lateinit var catsPresenter: CatsPresenter
 
@@ -15,7 +16,7 @@ class MainActivity : AppCompatActivity() {
         val view = layoutInflater.inflate(R.layout.activity_main, null) as CatsView
         setContentView(view)
 
-        catsPresenter = CatsPresenter(diContainer.service)
+        catsPresenter = CatsPresenter(diContainer.service, this)
         view.presenter = catsPresenter
         catsPresenter.attachView(view)
         catsPresenter.onInitComplete()
@@ -26,5 +27,14 @@ class MainActivity : AppCompatActivity() {
             catsPresenter.detachView()
         }
         super.onStop()
+        catsPresenter.cancelFetch()
+    }
+
+    override fun onError() {
+        Toast.makeText(
+            this,
+            getString(R.string.toast_failed_to_get_server_response),
+            Toast.LENGTH_LONG
+        ).show()
     }
 }

--- a/app/src/main/java/otus/homework/coroutines/MainActivity.kt
+++ b/app/src/main/java/otus/homework/coroutines/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import java.net.SocketTimeoutException
 
 class MainActivity : AppCompatActivity(), ConnectionErrorHandler {
 
@@ -45,14 +44,10 @@ class MainActivity : AppCompatActivity(), ConnectionErrorHandler {
         viewModel.catsLiveData.observe(this) { result ->
             when (result) {
                 is Result.Success -> view.populate(result.data)
-                is Result.Error -> handleError(result.exception)
+                is Result.Error.ServerError -> onError()
+                is Result.Error.GeneralError -> CrashMonitor.trackWarning(result.exception.message)
             }
         }
-    }
-
-    private fun handleError(exception: Throwable) = when (exception) {
-        is SocketTimeoutException -> onError()
-        else -> CrashMonitor.trackWarning(exception.message)
     }
 
     override fun onStop() {

--- a/app/src/main/java/otus/homework/coroutines/Picture.kt
+++ b/app/src/main/java/otus/homework/coroutines/Picture.kt
@@ -1,0 +1,8 @@
+package otus.homework.coroutines
+
+import com.google.gson.annotations.SerializedName
+
+data class Picture(
+    @field:SerializedName("url")
+    val url: String
+)

--- a/app/src/main/java/otus/homework/coroutines/PresenterScope.kt
+++ b/app/src/main/java/otus/homework/coroutines/PresenterScope.kt
@@ -1,0 +1,18 @@
+package otus.homework.coroutines
+
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlin.coroutines.CoroutineContext
+
+class PresenterScope : CoroutineScope {
+
+    private val job = Job()
+
+    override val coroutineContext: CoroutineContext
+        get() = job + Dispatchers.Main + CoroutineName("CatsCoroutine")
+
+
+    fun cancel() = job.cancel()
+}

--- a/app/src/main/java/otus/homework/coroutines/PresenterScope.kt
+++ b/app/src/main/java/otus/homework/coroutines/PresenterScope.kt
@@ -3,16 +3,10 @@ package otus.homework.coroutines
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlin.coroutines.CoroutineContext
 
 class PresenterScope : CoroutineScope {
 
-    private val job = Job()
-
     override val coroutineContext: CoroutineContext
-        get() = job + Dispatchers.Main + CoroutineName("CatsCoroutine")
-
-
-    fun cancel() = job.cancel()
+        get() = Dispatchers.Main + CoroutineName("CatsCoroutine")
 }

--- a/app/src/main/java/otus/homework/coroutines/Result.kt
+++ b/app/src/main/java/otus/homework/coroutines/Result.kt
@@ -1,0 +1,6 @@
+package otus.homework.coroutines
+
+sealed class Result<out T> {
+    data class Success<out T>(val data: T) : Result<T>()
+    data class Error(val exception: Throwable) : Result<Nothing>()
+}

--- a/app/src/main/java/otus/homework/coroutines/Result.kt
+++ b/app/src/main/java/otus/homework/coroutines/Result.kt
@@ -2,5 +2,8 @@ package otus.homework.coroutines
 
 sealed class Result<out T> {
     data class Success<out T>(val data: T) : Result<T>()
-    data class Error(val exception: Throwable) : Result<Nothing>()
+    sealed class Error(val exception: Throwable) : Result<Nothing>() {
+        class ServerError(exception: Throwable) : Error(exception)
+        class GeneralError(exception: Throwable) : Error(exception)
+    }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,20 +3,33 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:padding="16dp"
     android:layout_height="match_parent"
+    android:padding="16dp"
     tools:context=".MainActivity">
+
+    <ImageView
+        android:id="@+id/cat_image"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_max="300dp"
+        app:layout_constraintHeight_min="300dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_max="300dp"
+        app:layout_constraintWidth_min="300dp"
+        tools:src="@tools:sample/backgrounds/scenic" />
 
     <TextView
         android:id="@+id/fact_textView"
-        android:textColor="@color/black"
-        android:textSize="24sp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textColor="@color/black"
+        android:textSize="24sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/cat_image" />
 
     <Button
         android:id="@+id/button"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Cat Facts </string>
     <string name="more_facts">More Facts</string>
+    <string name="toast_failed_to_get_server_response">Failed to get server response</string>
 </resources>


### PR DESCRIPTION
# Coroutines Homework

### Перейти с коллбеков на саспенд функции и корутины

1. Поменять возвращаемый тип в `CatsService` и добавить модификатор `suspend`
2. Переписать логику в презентере с `Callback` на корутины и `suspend` функции
3. Реализовать свой скоуп: PresenterScope с `MainDispatcher` и CoroutineName("CatsCoroutine") в качестве элементов контекста
4. Добавить обработку исключений через try-catch. В случае `java.net.SocketTimeoutException` показываем Toast с текстом "Не удалось получить ответ от сервером". В остальных случаях логируем исключение в `otus.homework.coroutines.CrashMonitor` и показываем Toast с `exception.message`
5. Не забываем отменять Job в `onStop()`

### Добавить к запросу фактов запрос рандомных картинок с https://api.thecatapi.com/v1/images/search

1. На каждый рефреш экрана должен запрашиваться факт + картинка: добавляем сетевой запрос и реализуем логику аналогичную первой задаче. Для загрузки изображений уже подключена библиотека [Picasso](https://github.com/square/picasso)
2. В метод `view.populate` передаем 1 аргумент, поэтому необходимо реализовать модель презентейшен слоя в которой будут содержаться необходимые данные для рендеринга(текст и ссылка на картинку)
3. Отменятся запросы должны одновременно

### Реализовать решение ViewModel

1. Реализовать наследника `ViewModel` и продублировать в нем логику из `CatsPresenter`, с необходимыми изменениями. Используйте `viewModelScope` в качестве скоупа.
2. Добавить логирование ошибок через CoroutineExceptionHanlder. Используйте класс CrashMonitor в качестве фейкового CrashMonitor инструмента
3. Создать sealed класс `Result`. Унаследовать от него классы `Success<T>`, `Error`. Использовать эти классы как стейт необходимый для рендеринга/отображени ошибки
